### PR TITLE
Various Makefile fixes (including build flags)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,25 +8,21 @@ PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
 CFLAGS ?= -Wall -Og -g
 
-all:
-	$(MAKE) -C mini
-	$(MAKE) $(PROG)
+all: $(PROG)
 
-mini/ministub.exe:
+.PHONY: mini
+mini/ministub.exe: mini
 	$(MAKE) -C mini
 
 stub.exe: mini/ministub.exe
-	cp mini/ministub.exe $@
+	cp $< $@
 
 binstub.o: stub.exe
 	$(OBJCOPY) -I binary -O $(O_BFDARCH) \
 		--add-section .note.GNU-stack=/dev/null $< $@
 
 $(PROG): stubify.o binstub.o
-	$(CC) -o $@ $^
-
-stubify.o: stubify.c
-	$(CC) $(CFLAGS) $< -c -o $@
+	$(CC) $(LDFLAGS) -o $@ $^
 
 install:
 	install -d $(DESTDIR)$(BINDIR)
@@ -37,6 +33,7 @@ install:
 uninstall:
 	$(RM) $(DESTDIR)$(BINDIR)/$(PROG)
 	$(RM) $(DESTDIR)$(BINDIR)/djstrip
+	$(RM) $(DESTDIR)$(BINDIR)/djlink
 
 deb:
 	debuild -i -us -uc -b


### PR DESCRIPTION
* Change the all target to depend directly on $(PROG); this avoids an unnecessary sub-make. Calling make in the mini directory is done through the mini/ministub.exe target.
* Ensure ministub.exe is rebuilt if ministub.c is newer.
* Use the $< automatic variable in the stub.exe recipe to avoid repeating mini/ministub.exe.
* Apply $(LDFLAGS) when linking.
* Rely on the default rule to compile stubify.o. This ensures that the appropriate build flags are automatically applied.
* Uninstall djlink too.